### PR TITLE
Fixed create_uuid to be called on before_create, not after_initialize,…

### DIFF
--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -16,7 +16,7 @@ class Node < ApplicationRecord
   belongs_to :deactivated_by, class_name: "User"
 
   before_save :sanitise_blank_cost_code
-  after_create :create_uuid
+ before_create :create_uuid
 
   scope :active, -> { where(deactivated_by_id: nil) }
 

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -16,7 +16,7 @@ class Node < ApplicationRecord
   belongs_to :deactivated_by, class_name: "User"
 
   before_save :sanitise_blank_cost_code
- before_create :create_uuid
+  before_create :create_uuid
 
   scope :active, -> { where(deactivated_by_id: nil) }
 

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -16,7 +16,7 @@ class Node < ApplicationRecord
   belongs_to :deactivated_by, class_name: "User"
 
   before_save :sanitise_blank_cost_code
-  after_initialize :create_uuid
+  after_create :create_uuid
 
   scope :active, -> { where(deactivated_by_id: nil) }
 

--- a/spec/models/node_spec.rb
+++ b/spec/models/node_spec.rb
@@ -10,6 +10,13 @@ RSpec.describe Node, type: :model do
     expect(build(:node, name: 'name', cost_code: 'S1234')).to have_attribute('node_uuid')
   end
 
+  it "it has the same uuid after reloading again" do
+    nodes = create_list(:node, 3)
+    node = nodes.first
+    reloaded_node = nodes.find(node.id).first
+    expect(reloaded_node.node_uuid).to eq nodes.first.node_uuid
+  end
+
   it "is not valid without a name" do
     expect(build(:node, name: nil)).to_not be_valid
   end


### PR DESCRIPTION
… as every time the submission of a work order was failing, therefor reloading the node, the Product UUID (node_uuid) would change