### PR TITLE
Make it clear that direct descendants of the root node can't be edited

### DIFF
--- a/app/controllers/nodes_controller.rb
+++ b/app/controllers/nodes_controller.rb
@@ -108,7 +108,7 @@ class NodesController < ApplicationController
   end
 
   def check_write_permission_for_node(node)
-    Ability.new(current_user).can?(:write, node)
+    Ability.new(current_user).can?(:write, node) && !node.world_node?
   end
 
 end

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -50,6 +50,13 @@ class Node < ApplicationRecord
     parents.size + 1
   end
 
+  # Returns true if the node is a direct descendant of the root node so the modal
+  # can be clear that these nodes cannot be edited (even though they have world edit
+  # permission)
+  def world_node?
+    parent_id == 1
+  end
+
   # Gets the parents of a node,
   # starting from root, ending at the node's direct parent
 	def parents

--- a/app/views/nodes/modal.html.erb
+++ b/app/views/nodes/modal.html.erb
@@ -6,7 +6,7 @@
   <% end %>
 </div>
 
-<div class="model-body">
+<div class="modal-body">
   <% if !check_write_permission_for_node(@node) %>
     <div class="alert alert-warning" role="alert">
       You don't have permission to edit this article.

--- a/spec/features/nodes_spec.rb
+++ b/spec/features/nodes_spec.rb
@@ -55,11 +55,6 @@ RSpec.describe 'Nodes', type: :feature do
       expect(page).to have_link('program2', href: node_path(program2.id))
     end
 
-    it "you can edit or delete program level nodes" do
-      expect(page).to have_content('Edit')
-      expect(page).to have_content('Delete')
-    end
-
   end
 
   context 'when I visit the Tree Hierarchy', js: true do


### PR DESCRIPTION
Have also removed the test "you can edit or delete program level nodes" as this shouldn't be possible