### PR TITLE
Converting some columns to citext and adding sanitisation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,9 +10,9 @@ GIT
 
 GIT
   remote: git://github.com/sanger/aker-permission.git
-  revision: 39dead14c5ad4da60271dc2408a3208333b89407
+  revision: 3c8ea05a11a558bb912b84085323990e1192e64b
   specs:
-    aker_permission_gem (0.4.0)
+    aker_permission_gem (0.4.1)
       cancancan
 
 GIT
@@ -88,7 +88,7 @@ GEM
     bootstrap_form (2.7.0)
     builder (3.2.3)
     byebug (9.0.6)
-    cancancan (2.0.0)
+    cancancan (2.1.1)
     capybara (2.14.4)
       addressable
       mime-types (>= 1.16)
@@ -387,4 +387,4 @@ DEPENDENCIES
   zipkin-tracer
 
 BUNDLED WITH
-   1.16.0.pre.3
+   1.16.0

--- a/app/models/node.rb
+++ b/app/models/node.rb
@@ -18,7 +18,8 @@ class Node < ApplicationRecord
 	has_many :nodes, class_name: 'Node', foreign_key: 'parent_id', dependent: :restrict_with_error
 	belongs_to :parent, class_name: 'Node', required: false
 
-  before_save :sanitise_blank_cost_code
+  before_validation :sanitise_blank_cost_code, :sanitise_name, :sanitise_owner, :sanitise_deactivated_by
+  before_save :sanitise_blank_cost_code, :sanitise_name, :sanitise_owner, :sanitise_deactivated_by
   before_create :create_uuid
   before_destroy :validate_root_node_cant_be_destroyed
 
@@ -81,6 +82,33 @@ class Node < ApplicationRecord
 
   def active_children
     nodes.select(&:active?)
+  end
+
+  def sanitise_name
+    if name
+      sanitised = name.strip.gsub(/\s+/, ' ')
+      if sanitised != name
+        self.name = sanitised
+      end
+    end
+  end
+
+  def sanitise_owner
+    if owner_email
+      sanitised = owner_email.strip.downcase
+      if sanitised != owner_email
+        self.owner_email = sanitised
+      end
+    end
+  end
+
+  def sanitise_deactivated_by
+    if deactivated_by
+      sanitised = deactivated_by.strip.downcase
+      if sanitised != deactivated_by
+        self.deactivated_by = sanitised
+      end
+    end
   end
 
   private

--- a/app/models/tree_layout.rb
+++ b/app/models/tree_layout.rb
@@ -1,3 +1,16 @@
 class TreeLayout < ApplicationRecord
+  validates :user_id, presence: true, uniqueness: true
+
+  before_save :sanitise_user
+  before_validation :sanitise_user
+
+  def sanitise_user
+    if user_id
+      sanitised = user_id.strip.downcase
+      if sanitised != user_id
+        self.user_id = sanitised
+      end
+    end
+  end
   
 end

--- a/config/database.yml
+++ b/config/database.yml
@@ -5,21 +5,18 @@
 #   gem 'sqlite3'
 #
 default: &default
-  adapter: sqlite3
+  adapter: postgresql
   pool: 5
   timeout: 5000
 
 development:
   <<: *default
-  database: db/development.sqlite3
+  database: aker_study_development
 
 # Warning: The database defined as "test" will be erased and
 # re-generated from your development database when you run "rake".
 # Do not set this db to the same as development or production.
 test:
   <<: *default
-  database: db/test.sqlite3
+  database: aker_study_test
 
-production:
-  <<: *default
-  database: db/production.sqlite3

--- a/db/migrate/20171113125526_convert_columns_to_case_insensitive.rb
+++ b/db/migrate/20171113125526_convert_columns_to_case_insensitive.rb
@@ -1,0 +1,27 @@
+class ConvertColumnsToCaseInsensitive < ActiveRecord::Migration[5.0]
+  def up
+    enable_extension "citext"
+
+    change_column :nodes, :name, :citext, null: false
+    change_column :nodes, :owner_email, :citext, null: false
+    change_column :nodes, :deactivated_by, :citext
+    change_column :permissions, :permitted, :citext
+    change_column :tree_layouts, :user_id, :citext, null: false
+
+    add_index :tree_layouts, :user_id, unique: true
+
+    Node.find_each { |n| n.save! if [n.sanitise_name, n.sanitise_owner, n.sanitise_deactivated_by].any? } # non-short-circuiting OR
+    AkerPermissionGem::Permission.find_each { |p| p.save! if p.sanitise_permitted }
+    TreeLayout.find_each { |tl| tl.save! if tl.sanitise_user }
+  end
+
+  def down
+    change_column :nodes, :name, :string, null: true
+    change_column :nodes, :owner_email, :string, null: true
+    change_column :nodes, :deactivated_by, :string
+    change_column :permissions, :permitted, :string
+    change_column :tree_layouts, :user_id, :string, null: true
+
+    remove_index :tree_layouts, :user_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171025152542) do
+ActiveRecord::Schema.define(version: 20171113125526) do
+
+  # These are extensions that must be enabled in order to support this database
+  enable_extension "plpgsql"
+  enable_extension "citext"
 
   create_table "nodes", force: :cascade do |t|
-    t.string   "name"
+    t.citext   "name",                 null: false
     t.integer  "parent_id"
     t.datetime "created_at",           null: false
     t.datetime "updated_at",           null: false
@@ -21,31 +25,33 @@ ActiveRecord::Schema.define(version: 20171025152542) do
     t.string   "cost_code"
     t.datetime "deactivated_datetime"
     t.string   "node_uuid"
-    t.string   "owner_email"
-    t.string   "deactivated_by"
-    t.index ["cost_code"], name: "index_nodes_on_cost_code"
-    t.index ["name"], name: "index_nodes_on_name"
-    t.index ["owner_email"], name: "index_nodes_on_owner_email"
-    t.index ["parent_id"], name: "index_nodes_on_parent_id"
+    t.citext   "owner_email",          null: false
+    t.citext   "deactivated_by"
+    t.index ["cost_code"], name: "index_nodes_on_cost_code", using: :btree
+    t.index ["name"], name: "index_nodes_on_name", using: :btree
+    t.index ["owner_email"], name: "index_nodes_on_owner_email", using: :btree
+    t.index ["parent_id"], name: "index_nodes_on_parent_id", using: :btree
   end
 
   create_table "permissions", force: :cascade do |t|
-    t.string   "permitted",       null: false
+    t.citext   "permitted",       null: false
     t.string   "permission_type", null: false
     t.string   "accessible_type", null: false
     t.integer  "accessible_id",   null: false
     t.datetime "created_at",      null: false
     t.datetime "updated_at",      null: false
-    t.index ["accessible_type", "accessible_id"], name: "index_permissions_on_accessible_type_and_accessible_id"
-    t.index ["permitted", "permission_type", "accessible_id", "accessible_type"], name: "index_permissions_on_various", unique: true
-    t.index ["permitted"], name: "index_permissions_on_permitted"
+    t.index ["accessible_type", "accessible_id"], name: "index_permissions_on_accessible_type_and_accessible_id", using: :btree
+    t.index ["permitted", "permission_type", "accessible_id", "accessible_type"], name: "index_permissions_on_various", unique: true, using: :btree
+    t.index ["permitted"], name: "index_permissions_on_permitted", using: :btree
   end
 
   create_table "tree_layouts", force: :cascade do |t|
-    t.string   "user_id"
+    t.citext   "user_id",    null: false
     t.text     "layout"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["user_id"], name: "index_tree_layouts_on_user_id", unique: true, using: :btree
   end
 
+  add_foreign_key "nodes", "nodes", column: "parent_id"
 end

--- a/spec/factories/tree_layouts.rb
+++ b/spec/factories/tree_layouts.rb
@@ -1,4 +1,5 @@
 FactoryGirl.define do
   factory :tree_layout, class: TreeLayout do
+    user_id 'user@sanger.ac.uk'
   end
 end

--- a/spec/models/node_spec.rb
+++ b/spec/models/node_spec.rb
@@ -126,7 +126,7 @@ RSpec.describe Node, type: :model do
       expect(prog1).not_to be_valid
     end
 
-    it "is invalid to creat a node with the same name as another active node" do
+    it "is invalid to create a node with the same name as another active node" do
     	active_node = create(:node, parent: program1)
     	expect(build(:node, name: active_node.name, parent: program1)).not_to be_valid
   	 end

--- a/spec/models/node_spec.rb
+++ b/spec/models/node_spec.rb
@@ -37,131 +37,145 @@ RSpec.describe Node, type: :model do
     expect(root).not_to have_attribute('owner')
   end
 
-  it "is not valid without a name" do
-    expect(build(:node, name: nil, parent: program1)).to_not be_valid
+  describe '#validation' do
+
+    it "is not valid without a name" do
+      expect(build(:node, name: nil, parent: program1)).to_not be_valid
+    end
+
+    it "is not valid without a parent" do
+      root.reload
+      expect(build(:node, name: 'name')).to_not be_valid
+    end
+
+    it "is valid with a costcode in the correct format and without" do
+      expect(build(:node, name: 'name', cost_code: 'xx', parent: program1)).to_not be_valid
+      expect(build(:node, name: 'name', cost_code: 'S1234', parent: program1)).to be_valid
+      expect(build(:node, name: 'name', cost_code: nil, parent: program1)).to be_valid
+      expect(build(:node, name: 'name', cost_code: '', parent: program1)).to be_valid
+    end
+
+    it "is valid with all possible attributes" do
+      expect(build(:node, name: 'name', description: 'description', cost_code: 'S1234', parent: program1)).to be_valid
+    end
+
+    it "is valid when deactivated" do
+      expect(build(:node, deactivated_by: user.email, deactivated_datetime: DateTime.now, parent: program1)).to be_valid
+    end
+
+    it "is valid when active" do
+      expect(build(:node, deactivated_by: nil, deactivated_datetime: nil, parent: program1)).to be_valid
+    end
+
+    it "is not valid with a deactivated_datetime but no deactivated_by" do
+      expect(build(:node, deactivated_by: nil, deactivated_datetime: DateTime.now, parent: program1)).not_to be_valid
+    end
+
+    it "is not valid with a deactivated_by but no deactivated_datetime" do
+      expect(build(:node, deactivated_by: user.email, deactivated_datetime: nil, parent: program1)).not_to be_valid
+    end
+
+    it "is valid to be active and have active children" do
+      children = create_list(:node, 3, parent: program1)
+      expect(program1.nodes).to eq children
+    end
+
+    it "is valid to be active and have inactive children" do
+      children = create_list(:node, 3, deactivated_by: user.email, deactivated_datetime: DateTime.now, parent: program1)
+      expect(program1.nodes).to eq children
+    end
+
+    it "is valid to be active and have partially inactive children" do
+      children = create_list(:node, 2,  deactivated_by: nil, deactivated_datetime: nil, parent: program1)
+      children += create_list(:node, 2, deactivated_by: user.email, deactivated_datetime: DateTime.now, parent: program1)
+      expect(program1.nodes).to eq children
+    end
+
+    it "is valid to be active and have no children" do
+      expect(create(:node, parent: program1)).to be_valid
+    end
+
+    it "is valid to be inactive and have no children" do
+      expect(create(:node, deactivated_by: user.email, deactivated_datetime: DateTime.now, parent: program1)).to be_valid
+    end
+
+    it "is valid to be inactive and have inactive children" do
+      prog1 = create(:node, parent: program1)
+      children = create_list(:node, 3, deactivated_by: user.email, deactivated_datetime: DateTime.now, parent: prog1)
+      expect(prog1.nodes).to eq children
+      prog1.deactivated_by = user
+      prog1.deactivated_datetime = DateTime.now
+      expect(prog1).to be_valid
+    end
+
+    it "is invalid to be inactive and have active children" do
+      prog1 = create(:node, parent: program1)
+      children = create_list(:node, 3, parent: prog1)
+      expect(prog1.nodes).to eq children
+      prog1.deactivated_by = user.email
+      prog1.deactivated_datetime = DateTime.now
+      expect(prog1).not_to be_valid
+    end
+
+    it "is invalid to be inactive and have partially inactive children" do
+      prog1 = create(:node, parent: program1)
+      children = create_list(:node, 2, deactivated_by: nil, deactivated_datetime: nil, parent: prog1)
+      children += create_list(:node, 2, deactivated_by: user.email, deactivated_datetime: DateTime.now, parent: prog1)
+      prog1.deactivated_by = user.email
+      prog1.deactivated_datetime = DateTime.now
+      expect(prog1).not_to be_valid
+    end
+
+    it "is invalid to creat a node with the same name as another active node" do
+    	active_node = create(:node, parent: program1)
+    	expect(build(:node, name: active_node.name, parent: program1)).not_to be_valid
+  	 end
+
+    it "is valid to create a node with the same name as a deactivated node" do
+    	deactivated_node = create(:node, deactivated_by: user.email, deactivated_datetime: DateTime.now, parent: program1)
+    	expect(build(:node, name: deactivated_node.name, parent: program1)).to be_valid
+    end
+
+    it "is invalid to create a root node" do
+      root.reload
+      expect(build(:node, name: 'root', parent: nil)).not_to be_valid
+    end
+
+    it "is invalid to create a node under root" do
+      expect(build(:node, name: 'prog1', parent: root)).not_to be_valid
+    end
+
+    it "is invalid to move a node to under root" do
+      node =  build(:node, name: 'prog1', parent: program1)
+      node.update_attributes(parent_id: root.id)
+      expect(node).not_to be_valid
+    end
+
+    it "is invalid to move a node from under root" do
+      program3 = create(:node, name: 'program3', parent: program1, owner_email: user.email)
+      program4 = build(:node, name: 'program4', parent: root, owner_email: user.email)
+      program4.save(validate: false)
+      expect(program4.update_attributes(parent_id: program3.id)).to eq false
+    end
+
+    it "is invalid to destroy the root node" do
+      root.destroy
+      expect(root.errors[:base]).to eq ["The root node cannot be deleted"]
+    end
+
+    it 'should not be valid without a sanitised name' do
+      expect(build(:node, parent: program1, name: "   \t  \n   ")).not_to be_valid
+    end
+    it 'should not be valid without a sanitised owner' do
+      expect(build(:node, parent: program1, owner_email: "   \t  \n   ")).not_to be_valid
+    end
+    it 'should be valid after sanitisation if fields are not empty' do
+      expect(build(:node, parent: program1, name: "   \tALPHA\n   ", owner_email: "   \tALPHA\n   ")).to be_valid
+    end
+
   end
 
-  it "is not valid without a parent" do
-    root.reload
-    expect(build(:node, name: 'name')).to_not be_valid
-  end
-
-  it "is valid with a costcode in the correct format and without" do
-    expect(build(:node, name: 'name', cost_code: 'xx', parent: program1)).to_not be_valid
-    expect(build(:node, name: 'name', cost_code: 'S1234', parent: program1)).to be_valid
-    expect(build(:node, name: 'name', cost_code: nil, parent: program1)).to be_valid
-    expect(build(:node, name: 'name', cost_code: '', parent: program1)).to be_valid
-  end
-
-  it "is valid with all possible attributes" do
-    expect(build(:node, name: 'name', description: 'description', cost_code: 'S1234', parent: program1)).to be_valid
-  end
-
-  it "is valid when deactivated" do
-    expect(build(:node, deactivated_by: user.email, deactivated_datetime: DateTime.now, parent: program1)).to be_valid
-  end
-
-  it "is valid when active" do
-    expect(build(:node, deactivated_by: nil, deactivated_datetime: nil, parent: program1)).to be_valid
-  end
-
-  it "is not valid with a deactivated_datetime but no deactivated_by" do
-    expect(build(:node, deactivated_by: nil, deactivated_datetime: DateTime.now, parent: program1)).not_to be_valid
-  end
-
-  it "is not valid with a deactivated_by but no deactivated_datetime" do
-    expect(build(:node, deactivated_by: user.email, deactivated_datetime: nil, parent: program1)).not_to be_valid
-  end
-
-  it "is valid to be active and have active children" do
-    children = create_list(:node, 3, parent: program1)
-    expect(program1.nodes).to eq children
-  end
-
-  it "is valid to be active and have inactive children" do
-    children = create_list(:node, 3, deactivated_by: user.email, deactivated_datetime: DateTime.now, parent: program1)
-    expect(program1.nodes).to eq children
-  end
-
-  it "is valid to be active and have partially inactive children" do
-    children = create_list(:node, 2,  deactivated_by: nil, deactivated_datetime: nil, parent: program1)
-    children += create_list(:node, 2, deactivated_by: user.email, deactivated_datetime: DateTime.now, parent: program1)
-    expect(program1.nodes).to eq children
-  end
-
-  it "is valid to be active and have no children" do
-    expect(create(:node, parent: program1)).to be_valid
-  end
-
-  it "is valid to be inactive and have no children" do
-    expect(create(:node, deactivated_by: user.email, deactivated_datetime: DateTime.now, parent: program1)).to be_valid
-  end
-
-  it "is valid to be inactive and have inactive children" do
-    prog1 = create(:node, parent: program1)
-    children = create_list(:node, 3, deactivated_by: user.email, deactivated_datetime: DateTime.now, parent: prog1)
-    expect(prog1.nodes).to eq children
-    prog1.deactivated_by = user
-    prog1.deactivated_datetime = DateTime.now
-    expect(prog1).to be_valid
-  end
-
-  it "is invalid to be inactive and have active children" do
-    prog1 = create(:node, parent: program1)
-    children = create_list(:node, 3, parent: prog1)
-    expect(prog1.nodes).to eq children
-    prog1.deactivated_by = user.email
-    prog1.deactivated_datetime = DateTime.now
-    expect(prog1).not_to be_valid
-  end
-
-  it "is invalid to be inactive and have partially inactive children" do
-    prog1 = create(:node, parent: program1)
-    children = create_list(:node, 2, deactivated_by: nil, deactivated_datetime: nil, parent: prog1)
-    children += create_list(:node, 2, deactivated_by: user.email, deactivated_datetime: DateTime.now, parent: prog1)
-    prog1.deactivated_by = user.email
-    prog1.deactivated_datetime = DateTime.now
-    expect(prog1).not_to be_valid
-  end
-
-  it "is invalid to creat a node with the same name as another active node" do
-  	active_node = create(:node, parent: program1)
-  	expect(build(:node, name: active_node.name, parent: program1)).not_to be_valid
-	 end
-
-  it "is valid to create a node with the same name as a deactivated node" do
-  	deactivated_node = create(:node, deactivated_by: user.email, deactivated_datetime: DateTime.now, parent: program1)
-  	expect(build(:node, name: deactivated_node.name, parent: program1)).to be_valid
-  end
-
-  it "is invalid to create a root node" do
-    root.reload
-    expect(build(:node, name: 'root', parent: nil)).not_to be_valid
-  end
-
-  it "is invalid to create a node under root" do
-    expect(build(:node, name: 'prog1', parent: root)).not_to be_valid
-  end
-
-  it "is invalid to move a node to under root" do
-    node =  build(:node, name: 'prog1', parent: program1)
-    node.update_attributes(parent_id: root.id)
-    expect(node).not_to be_valid
-  end
-
-  it "is invalid to move a node from under root" do
-    program3 = create(:node, name: 'program3', parent: program1, owner_email: user.email)
-    program4 = build(:node, name: 'program4', parent: root, owner_email: user.email)
-    program4.save(validate: false)
-    expect(program4.update_attributes(parent_id: program3.id)).to eq false
-  end
-
-  it "is invalid to destroy the root node" do
-    root.destroy
-    expect(root.errors[:base]).to eq ["The root node cannot be deleted"]
-  end
-
-  context '#create' do
+  describe '#create' do
     before do
       @node = create(:node, name: 'jeff', parent: program1)
     end
@@ -347,6 +361,24 @@ RSpec.describe Node, type: :model do
       it { should be_able_to(:read, node) }
       it { should be_able_to(:write, node) }
       it { should_not be_able_to(:spend, node) }
+    end
+  end
+
+  describe '#name' do
+    it 'should be sanitised' do
+      expect(create(:node, name: '   ALPHA   BETA  ', parent: program1).name).to eq('ALPHA BETA')
+    end
+  end
+
+  describe '#owner_email' do
+    it 'should be sanitised' do
+      expect(create(:node, owner_email: '   ALPHA@BETA  ', parent: program1).owner_email).to eq('alpha@beta')
+    end
+  end
+
+  describe '#deactivated_by' do
+    it 'should be sanitised' do
+      expect(create(:node, parent: program1, deactivated_datetime: DateTime.now, deactivated_by: '  ALPHA@BETA  ').deactivated_by).to eq('alpha@beta')
     end
   end
 end

--- a/spec/models/tree_layout_spec.rb
+++ b/spec/models/tree_layout_spec.rb
@@ -1,0 +1,24 @@
+require 'rails_helper'
+
+RSpec.describe TreeLayout, type: :model do
+  describe '#user_id' do
+    it 'should be sanitised' do
+      expect(create(:tree_layout, user_id: '    ALPHA@BETA   ').user_id).to eq('alpha@beta')
+    end
+  end
+
+  describe 'validation' do
+    it 'should not be valid without a user id' do
+      expect(build(:tree_layout, user_id: "   \n  \t   ")).not_to be_valid
+    end
+    it 'should not be valid without a unique sanitised user id' do
+      create(:tree_layout, user_id: 'alpha@beta')
+      expect(build(:tree_layout, user_id: '    ALPHA@BETA  ')).not_to be_valid
+    end
+    it 'should be valid with a unique user id' do
+      create(:tree_layout, user_id: 'alpha@beta')
+      expect(build(:tree_layout, user_id: '    GAMMA@DELTA  ')).to be_valid
+    end
+  end
+
+end


### PR DESCRIPTION
Sanitisation:
* Node.name (strip and contract spaces)
* Node.owner_email (strip and downcase)
* Node.deactivated_by (strip and downcase)
* Permission.permitted (using permission gem version 0.4.1)
* TreeLayout.user_id (strip and downcase)

Added unique index for TreeLayout.user_id.
Added presence and uniqueness validation for TreeLayout.user_id.
Changed database config to use postgres instead of sqlite.

Also, unit tests, including tree_layout_spec, which didn't exist.