### PR TITLE
fix bug - can't open node dialog for root

### DIFF
--- a/app/views/nodes/_node_form.html.erb
+++ b/app/views/nodes/_node_form.html.erb
@@ -1,6 +1,6 @@
 <%= f.text_field :name, autocomplete: 'off', disabled: !write_permission %>
 <%= f.text_field :description, disabled: !write_permission %>
-<% if Node.find(@node.parent_id).cost_code %>
+<% if @node.parent&.cost_code %>
   <%= f.select :cost_code, subcostcodes_select_options(@node),{include_blank: true}, {disabled: !write_permission } %>
 <% else %>
   <%= f.text_field :cost_code, disabled: !write_permission, autocomplete: 'off' %>


### PR DESCRIPTION
Node.find(@node.parent_id) raises an exception if parent_id is nil